### PR TITLE
Addition of parameter to switch focus to the Terminal.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ Open your keybindings.json (Command Palette => 'Preferences: Open Keyboard Short
           "cmd": "echo 'hello from file: ${file}'",
           "newTerminal": false,
           "saveAllFiles": true,
-          "showTerminal": true
+          "showTerminal": true,
+          "focus": true
       }
   }
 ```
@@ -66,6 +67,13 @@ If false, does not save all files before running the command.
 If true, ensures that the terminal is showing when running the command.
 
 If false, does not change the visibility of the terminal when running the command.
+
+---
+### "focus" : options, default false, locked to false if "showTerminal" is false
+
+If true, ensures that the terminal is focused when running the command.
+
+If false, focus is not applied to the terminal when running the command.
 
 ---
 

--- a/extension.js
+++ b/extension.js
@@ -46,14 +46,20 @@ function getTerminal(newTerminal) {
 // END TERMINAL
 
 function resolve(editor, command) {
-    var relativeFile = "." + editor.document.fileName.replace(vscode.workspace.rootPath, "");
+    // Create a workspace variable for the first workspace folder opened. 
+    // May be undefined if no workspace is opened.
+    var workspace = undefined;
+    if (vscode.workspace.workspaceFolders.length > 0) {
+        workspace = vscode.workspace.workspaceFolders[0].uri.fsPath;
+    }
+    var relativeFile = "." + editor.document.fileName.replace(workspace, "");
     var line = editor.selection.active.line + 1;
 
     return command
         .replace(/\${line}/g, `${line}`)
         .replace(/\${relativeFile}/g, relativeFile)
         .replace(/\${file}/g, `${editor.document.fileName}`)
-        .replace(/\${workspaceRoot}/g, `${vscode.workspace.rootPath}`);
+        .replace(/\${workspaceRoot}/g, `${workspace}`);
 }
 
 function run(command, showTerminal, newTerminal, focus) {

--- a/extension.js
+++ b/extension.js
@@ -56,13 +56,17 @@ function resolve(editor, command) {
         .replace(/\${workspaceRoot}/g, `${vscode.workspace.rootPath}`);
 }
 
-function run(command, showTerminal, newTerminal) {
+function run(command, showTerminal, newTerminal, focus) {
     const terminal = getTerminal(newTerminal);
 
     if (showTerminal) {
         terminal.show(true);
     }
     vscode.commands.executeCommand('workbench.action.terminal.scrollToBottom')
+    // Focus on the terminal if focus is set to true.
+    if (focus){
+        vscode.commands.executeCommand('workbench.action.terminal.focus')
+    }
     terminal.sendText(command, true)
 }
 
@@ -88,7 +92,8 @@ function handleInput(editor, args) {
         run(
             cmd,
             args.showTerminal,
-            args.newTerminal
+            args.newTerminal,
+            args.focus
         );
     });
 }
@@ -109,9 +114,14 @@ function activate(context) {
         const defaults = {
             showTerminal: true,
             saveAllFiles: true,
-            newTerminal: false
+            newTerminal: false,
+            focus: false,
         }
         const realArgs = Object.assign(defaults, args)
+        // If showTerminal is false, then focus should always be false, as we do not wish to focus on a terminal that should not be shown.
+        if (!realArgs.showTerminal){
+            realArgs.focus = false;
+        }
 
         handleInput(editor, realArgs)
     });


### PR DESCRIPTION
## Description
Addition of much needed `focus` parameter, which automatically puts focus on the terminal whenever a command is running. This new parameter is defaulted to `false`, and locked to false if `showTerminal` is `false`.<br>
Furthermore, I resolved a deprecation warning regarding `vscode.workspace.rootPath`.

## Motivation and Context
It's not uncommon for me to write something in VSCode, and then need to run some general commands in the terminal. For instance, if I want to quickly compile my current Haskell file, or quickly test some things in a Python interpreter, I would have to open the terminal and manually enter these commands.<br>
This is an issue this extension solved to some extent, with as only downside that I still had to (in some cases) change focus from my editor to the terminal.<br>
This pull request serves to eliminate this downside by giving users a choice to automatically focus on the terminal.

## How Has This Been Tested?
As the project itself does not rely on tests to ensure correctness, I neglected to create tests to verify the suggested changes.

## Types of changes
- [x] Implementation of `focus` option.
- [x] Fix of deprecation warning.
- [x] Updated the documentation accordingly.
